### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCES=$(wildcard *.go **/*.go **/**/*.go)
+SOURCES=$(filter-out ui, $(wildcard *.go **/*.go **/**/*.go))
 
 all: gitchain
 


### PR DESCRIPTION
Excluding ui from sources to get rid of

```
> go get github.com/gitchain/gitchain
gitchain/gitchain/server/http/http.go:14:2: no buildable Go source files in <$GOPATH>/src/github.com/gitchain/gitchain/ui
```
